### PR TITLE
Complete element wrappers coverage. Add library options.

### DIFF
--- a/pkg/elements/edge.go
+++ b/pkg/elements/edge.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2025 The Protobom Authors
+
+package elements
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+	"github.com/protobom/protobom/pkg/sbom"
+)
+
+var EdgeType = cel.ObjectType("protobom.protobom.Edge")
+
+type Edge struct {
+	*sbom.Edge
+}
+
+// ConvertToNative implements ref.Val.ConvertToNative.
+func (e *Edge) ConvertToNative(typeDesc reflect.Type) (any, error) {
+	if reflect.TypeOf(e).AssignableTo(typeDesc) {
+		return e, nil
+	} else if reflect.TypeOf(e.Edge).AssignableTo(typeDesc) {
+		return e.Edge, nil
+	}
+
+	return nil, fmt.Errorf("type conversion error from 'Edge' to '%v'", typeDesc)
+}
+
+// ConvertToType implements ref.Val.ConvertToType.
+func (e *Edge) ConvertToType(typeVal ref.Type) ref.Val {
+	switch typeVal {
+	case EdgeType:
+		return e
+		// TODO(puerco): Add sbom.Doc type conversion
+	case types.TypeType:
+		return DocumentType
+	}
+	return types.NewErr("type conversion error from '%s' to '%s'", EdgeType, typeVal)
+}
+
+// Equal implements ref.Val.Equal.
+func (e *Edge) Equal(other ref.Val) ref.Val {
+	// TODO(puerco): Implement with e.Edge.Equal()
+	return types.MaybeNoSuchOverloadErr(other)
+}
+
+func (*Edge) Type() ref.Type {
+	return EdgeType
+}
+
+// Value implements ref.Val.Value.
+func (e *Edge) Value() any {
+	return e.Edge
+}
+
+var _ traits.Indexer = (*Document)(nil)
+
+// Get is the getter to implement the indexer trait
+func (e *Edge) Get(index ref.Val) ref.Val {
+	switch v := index.Value().(type) {
+	case string:
+		switch v {
+		case "type":
+			if _, ok := sbom.Edge_Type_name[int32(e.GetType())]; ok {
+				return types.String(sbom.Edge_Type_name[int32(e.GetType())])
+			}
+			return types.String(sbom.Edge_Type_name[0])
+		case "from":
+			return types.String(e.From)
+		case "to":
+			return types.NewDynamicList(types.DefaultTypeAdapter, e.To)
+		default:
+			return types.NewErr("no such key %v", index)
+		}
+
+	default:
+		return types.NewErr("no such key %v", index)
+	}
+}

--- a/pkg/elements/edge.go
+++ b/pkg/elements/edge.go
@@ -58,14 +58,14 @@ func (e *Edge) Value() any {
 	return e.Edge
 }
 
-var _ traits.Indexer = (*Document)(nil)
+var _ traits.Indexer = (*Edge)(nil)
 
 // Get is the getter to implement the indexer trait
 func (e *Edge) Get(index ref.Val) ref.Val {
 	switch v := index.Value().(type) {
 	case string:
 		switch v {
-		case "type":
+		case propType:
 			if _, ok := sbom.Edge_Type_name[int32(e.GetType())]; ok {
 				return types.String(sbom.Edge_Type_name[int32(e.GetType())])
 			}

--- a/pkg/elements/elements.go
+++ b/pkg/elements/elements.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2025 The Protobom Authors
+
+// Package elements has wrappers of the protobom elements (from the
+// main protobuf definition) that implement the ref.Val interface
+// used by the CEL runtime. This lets the library expose them natively
+// in the CEL evaluation environment.
+//
+// As of v0.1.0 the elements package has a complete wrappers library
+// for the native elements defined in protobom v0.5.x.
+package elements
+
+// Constants for common property names
+const (
+	propType    = "type"
+	propHashes  = "hashes"
+	propComment = "comment"
+	propName    = "name"
+	propVersion = "version"
+)

--- a/pkg/elements/externalreference.go
+++ b/pkg/elements/externalreference.go
@@ -64,18 +64,18 @@ func (er *ExternalReference) Get(index ref.Val) ref.Val {
 	switch v := index.Value().(type) {
 	case string:
 		switch v {
-		case "type":
+		case propType:
 			if _, ok := sbom.Edge_Type_name[int32(er.GetType())]; ok {
 				return types.String(sbom.ExternalReference_ExternalReferenceType_name[int32(er.GetType())])
 			}
 			return types.String(sbom.ExternalReference_ExternalReferenceType_name[0])
 		case "url":
 			return types.String(er.Url)
-		case "comment":
+		case propComment:
 			return types.String(er.Comment)
 		case "authority":
 			return types.String(er.Authority)
-		case "hashes":
+		case propHashes:
 			ret := map[string]string{}
 			for a, v := range er.Hashes {
 				if _, ok := sbom.HashAlgorithm_name[a]; ok {

--- a/pkg/elements/externalreference.go
+++ b/pkg/elements/externalreference.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2025 The Protobom Authors
+
+package elements
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+	"github.com/protobom/protobom/pkg/sbom"
+)
+
+var ExternalReferenceType = cel.ObjectType("protobom.protobom.ExternalReference")
+
+type ExternalReference struct {
+	*sbom.ExternalReference
+}
+
+// ConvertToNative implements ref.Val.ConvertToNative.
+func (er *ExternalReference) ConvertToNative(typeDesc reflect.Type) (any, error) {
+	if reflect.TypeOf(er).AssignableTo(typeDesc) {
+		return er, nil
+	} else if reflect.TypeOf(er.ExternalReference).AssignableTo(typeDesc) {
+		return er.ExternalReference, nil
+	}
+
+	return nil, fmt.Errorf("type conversion error from 'ExternalReference' to '%v'", typeDesc)
+}
+
+// ConvertToType implements ref.Val.ConvertToType.
+func (er *ExternalReference) ConvertToType(typeVal ref.Type) ref.Val {
+	switch typeVal {
+	case ExternalReferenceType:
+		return er
+	case types.TypeType:
+		return DocumentType
+	}
+	return types.NewErr("type conversion error from '%s' to '%s'", ExternalReferenceType, typeVal)
+}
+
+// Equal implements ref.Val.Equal.
+func (er *ExternalReference) Equal(other ref.Val) ref.Val {
+	// TODO(puerco): Implement with e.Edge.Equal()
+	return types.MaybeNoSuchOverloadErr(other)
+}
+
+func (*ExternalReference) Type() ref.Type {
+	return ExternalReferenceType
+}
+
+// Value implements ref.Val.Value.
+func (er *ExternalReference) Value() any {
+	return er.ExternalReference
+}
+
+var _ traits.Indexer = (*ExternalReference)(nil)
+
+// Get is the getter to implement the indexer trait
+func (er *ExternalReference) Get(index ref.Val) ref.Val {
+	switch v := index.Value().(type) {
+	case string:
+		switch v {
+		case "type":
+			if _, ok := sbom.Edge_Type_name[int32(er.GetType())]; ok {
+				return types.String(sbom.ExternalReference_ExternalReferenceType_name[int32(er.GetType())])
+			}
+			return types.String(sbom.ExternalReference_ExternalReferenceType_name[0])
+		case "url":
+			return types.String(er.Url)
+		case "comment":
+			return types.String(er.Comment)
+		case "authority":
+			return types.String(er.Authority)
+		case "hashes":
+			ret := map[string]string{}
+			for a, v := range er.Hashes {
+				if _, ok := sbom.HashAlgorithm_name[a]; ok {
+					ret[sbom.HashAlgorithm_name[a]] = v
+				} else {
+					ret[sbom.HashAlgorithm_name[0]] = v
+				}
+			}
+			return types.NewDynamicMap(types.DefaultTypeAdapter, ret)
+		default:
+			return types.NewErr("no such key %v", index)
+		}
+
+	default:
+		return types.NewErr("no such key %v", index)
+	}
+}

--- a/pkg/elements/metadata.go
+++ b/pkg/elements/metadata.go
@@ -67,15 +67,15 @@ func (md *Metadata) Get(index ref.Val) ref.Val {
 		switch v {
 		case "id":
 			return types.String(md.Id)
-		case "name":
+		case propName:
 			return types.String(md.Name)
-		case "version":
+		case propVersion:
 			return types.String(md.Version)
 		case "tools":
 			return types.NewDynamicList(types.DefaultTypeAdapter, md.Tools)
 		case "date":
 			return types.Timestamp{Time: md.Date.AsTime()}
-		case "comment":
+		case propComment:
 			return types.String(md.Comment)
 		default:
 			return types.NewErr("no such key %v", index)

--- a/pkg/elements/metadata.go
+++ b/pkg/elements/metadata.go
@@ -72,11 +72,29 @@ func (md *Metadata) Get(index ref.Val) ref.Val {
 		case propVersion:
 			return types.String(md.Version)
 		case "tools":
-			return types.NewDynamicList(types.DefaultTypeAdapter, md.Tools)
+			toolsList := make([]ref.Val, len(md.Tools))
+			for i, t := range md.Tools {
+				toolsList[i] = &Tool{
+					Tool: t,
+				}
+			}
+			return types.NewRefValList(types.DefaultTypeAdapter, toolsList)
+		case "authors":
+			authorsList := make([]ref.Val, len(md.Authors))
+			for i, p := range md.Authors {
+				authorsList[i] = &Person{
+					Person: p,
+				}
+			}
+			return types.NewRefValList(types.DefaultTypeAdapter, authorsList)
 		case "date":
 			return types.Timestamp{Time: md.Date.AsTime()}
 		case propComment:
 			return types.String(md.Comment)
+		case "source_data":
+			return &SourceData{
+				SourceData: md.SourceData,
+			}
 		default:
 			return types.NewErr("no such key %v", index)
 		}

--- a/pkg/elements/node.go
+++ b/pkg/elements/node.go
@@ -88,11 +88,11 @@ func (n *Node) Get(index ref.Val) ref.Val {
 		switch v {
 		case "id":
 			return types.String(n.Id)
-		case "name":
+		case propName:
 			return types.String(n.Name)
-		case "type":
+		case propType:
 			return types.String(n.Node.Type.String())
-		case "version":
+		case propVersion:
 			return types.String(n.Version)
 		case "file_name":
 			return types.String(n.FileName)
@@ -110,7 +110,7 @@ func (n *Node) Get(index ref.Val) ref.Val {
 			return types.String(n.Copyright)
 		case "source_info":
 			return types.String(n.SourceInfo)
-		case "comment":
+		case propComment:
 			return types.String(n.Comment)
 		case "summary":
 			return types.String(n.Summary)
@@ -157,7 +157,7 @@ func (n *Node) Get(index ref.Val) ref.Val {
 				}
 			}
 			return types.NewDynamicMap(types.DefaultTypeAdapter, ret)
-		case "hashes":
+		case propHashes:
 			ret := map[string]string{}
 			for a, v := range n.Hashes {
 				if _, ok := sbom.HashAlgorithm_name[a]; ok {

--- a/pkg/elements/nodelist.go
+++ b/pkg/elements/nodelist.go
@@ -133,8 +133,9 @@ var _ traits.Indexer = (*NodeList)(nil)
 func (nl *NodeList) Get(index ref.Val) ref.Val {
 	switch v := index.Value().(type) {
 	case string:
-		if v == "nodes" {
-			nodesList := make([]ref.Val, len(v))
+		switch v {
+		case "nodes":
+			nodesList := make([]ref.Val, len(nl.Nodes))
 			for i, node := range nl.Nodes {
 				n := Node{
 					Node: node,
@@ -142,8 +143,16 @@ func (nl *NodeList) Get(index ref.Val) ref.Val {
 				nodesList[i] = n.ConvertToType(NodeType)
 			}
 			return types.NewRefValList(types.DefaultTypeAdapter, nodesList)
+		case "edges":
+			edgeList := make([]ref.Val, len(nl.Edges))
+			for i, e := range nl.Edges {
+				edgeList[i] = &Edge{
+					Edge: e,
+				}
+			}
+			return types.NewRefValList(types.DefaultTypeAdapter, edgeList)
 		}
-		return types.NewErr("no such key %v", index)
+		return types.NewErr("no such key in edge: %v", index)
 	default:
 		return types.NewErr("no such key %v", index)
 	}

--- a/pkg/elements/property.go
+++ b/pkg/elements/property.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2025 The Protobom Authors
+
+package elements
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+	"github.com/protobom/protobom/pkg/sbom"
+)
+
+var PropertyType = cel.ObjectType("protobom.protobom.Property")
+
+type Property struct {
+	*sbom.Property
+}
+
+// ConvertToNative implements ref.Val.ConvertToNative.
+func (p *Property) ConvertToNative(typeDesc reflect.Type) (any, error) {
+	if reflect.TypeOf(p).AssignableTo(typeDesc) {
+		return p, nil
+	} else if reflect.TypeOf(p.Property).AssignableTo(typeDesc) {
+		return p.Property, nil
+	}
+
+	return nil, fmt.Errorf("type conversion error from 'Property' to '%v'", typeDesc)
+}
+
+// ConvertToType implements ref.Val.ConvertToType.
+func (p *Property) ConvertToType(typeVal ref.Type) ref.Val {
+	switch typeVal {
+	case PropertyType:
+		return p
+	case types.TypeType:
+		return DocumentType
+	}
+	return types.NewErr("type conversion error from '%s' to '%s'", PropertyType, typeVal)
+}
+
+// Equal implements ref.Val.Equal.
+func (p *Property) Equal(other ref.Val) ref.Val {
+	return types.MaybeNoSuchOverloadErr(other)
+}
+
+func (*Property) Type() ref.Type {
+	return PropertyType
+}
+
+// Value implements ref.Val.Value.
+func (p *Property) Value() any {
+	return p.Property
+}
+
+var _ traits.Indexer = (*Property)(nil)
+
+// Get is the getter to implement the indexer trait
+func (p *Property) Get(index ref.Val) ref.Val {
+	switch v := index.Value().(type) {
+	case string:
+		switch v {
+		case "name":
+			return types.String(p.Name)
+		case "data":
+			return types.String(p.Data)
+		default:
+			return types.NewErr("no such key %v", index)
+		}
+
+	default:
+		return types.NewErr("no such key %v", index)
+	}
+}

--- a/pkg/elements/property.go
+++ b/pkg/elements/property.go
@@ -63,7 +63,7 @@ func (p *Property) Get(index ref.Val) ref.Val {
 	switch v := index.Value().(type) {
 	case string:
 		switch v {
-		case "name":
+		case propName:
 			return types.String(p.Name)
 		case "data":
 			return types.String(p.Data)

--- a/pkg/elements/sourcedata.go
+++ b/pkg/elements/sourcedata.go
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2025 The Protobom Authors
+
+package elements
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+	"github.com/protobom/protobom/pkg/sbom"
+)
+
+var SourceDataType = cel.ObjectType("protobom.protobom.SourceData")
+
+type SourceData struct {
+	*sbom.SourceData
+}
+
+// ConvertToNative implements ref.Val.ConvertToNative.
+func (sd *SourceData) ConvertToNative(typeDesc reflect.Type) (any, error) {
+	if reflect.TypeOf(sd).AssignableTo(typeDesc) {
+		return sd, nil
+	} else if reflect.TypeOf(sd.SourceData).AssignableTo(typeDesc) {
+		return sd.SourceData, nil
+	}
+
+	return nil, fmt.Errorf("type conversion error from '%s' to '%v'", SourceDataType, typeDesc)
+}
+
+// ConvertToType implements ref.Val.ConvertToType.
+func (sd *SourceData) ConvertToType(typeVal ref.Type) ref.Val {
+	switch typeVal {
+	case SourceDataType:
+		return sd
+	case types.TypeType:
+		return SourceDataType
+	}
+	return types.NewErr("type conversion error from '%s' to '%s'", SourceDataType, typeVal)
+}
+
+// Equal implements ref.Val.Equal.
+func (sd *SourceData) Equal(other ref.Val) ref.Val {
+	return types.MaybeNoSuchOverloadErr(other)
+}
+
+func (*SourceData) Type() ref.Type {
+	return SourceDataType
+}
+
+// Value implements ref.Val.Value.
+func (sd *SourceData) Value() any {
+	return sd.SourceData
+}
+
+var _ traits.Indexer = (*SourceData)(nil)
+
+// Get is the getter to implement the indexer trait
+func (sd *SourceData) Get(index ref.Val) ref.Val {
+	switch v := index.Value().(type) {
+	case string:
+		switch v {
+		case "format":
+			return types.String(sd.Format)
+		case "size":
+			return types.Int(sd.Size)
+		case "uri":
+			if sd.Uri != nil {
+				return types.String(*sd.Uri)
+			}
+			return types.String("")
+		case propHashes:
+			ret := map[string]string{}
+			for a, v := range sd.Hashes {
+				if _, ok := sbom.HashAlgorithm_name[a]; ok {
+					ret[sbom.HashAlgorithm_name[a]] = v
+				} else {
+					ret[sbom.HashAlgorithm_name[0]] = v
+				}
+			}
+			return types.NewDynamicMap(types.DefaultTypeAdapter, ret)
+		default:
+			return types.NewErr("no such key %v", index)
+		}
+
+	default:
+		return types.NewErr("no such key %v", index)
+	}
+}

--- a/pkg/elements/tool.go
+++ b/pkg/elements/tool.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2025 The Protobom Authors
+
+package elements
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+	"github.com/protobom/protobom/pkg/sbom"
+)
+
+var ToolType = cel.ObjectType("protobom.protobom.Tool")
+
+type Tool struct {
+	*sbom.Tool
+}
+
+// ConvertToNative implements ref.Val.ConvertToNative.
+func (t *Tool) ConvertToNative(typeDesc reflect.Type) (any, error) {
+	if reflect.TypeOf(t).AssignableTo(typeDesc) {
+		return t, nil
+	} else if reflect.TypeOf(t.Tool).AssignableTo(typeDesc) {
+		return t.Tool, nil
+	}
+
+	return nil, fmt.Errorf("type conversion error from '%s' to '%v'", ToolType, typeDesc)
+}
+
+// ConvertToType implements ref.Val.ConvertToType.
+func (t *Tool) ConvertToType(typeVal ref.Type) ref.Val {
+	switch typeVal {
+	case ToolType:
+		return t
+	case types.TypeType:
+		return ToolType
+	}
+	return types.NewErr("type conversion error from '%s' to '%s'", ToolType, typeVal)
+}
+
+// Equal implements ref.Val.Equal.
+func (t *Tool) Equal(other ref.Val) ref.Val {
+	return types.MaybeNoSuchOverloadErr(other)
+}
+
+func (*Tool) Type() ref.Type {
+	return ToolType
+}
+
+// Value implements ref.Val.Value.
+func (t *Tool) Value() any {
+	return t.Tool
+}
+
+var _ traits.Indexer = (*Tool)(nil)
+
+// Get is the getter to implement the indexer trait
+func (t *Tool) Get(index ref.Val) ref.Val {
+	switch v := index.Value().(type) {
+	case string:
+		switch v {
+		case propName:
+			return types.String(t.Name)
+		case propVersion:
+			return types.String(t.Version)
+		case "vendor":
+			return types.String(t.Vendor)
+		default:
+			return types.NewErr("no such key %v", index)
+		}
+
+	default:
+		return types.NewErr("no such key %v", index)
+	}
+}

--- a/pkg/functions/functions.go
+++ b/pkg/functions/functions.go
@@ -298,8 +298,8 @@ var RelateNodeListAtID = func(vals ...ref.Val) ref.Val {
 	}
 }
 
-// DocumentAuthors returns the document authors in a generic struct
-var DocumentAuthors = func(lhs ref.Val) ref.Val {
+// GetAuthors returns the document authors in a generic struct
+var GetAuthors = func(lhs ref.Val) ref.Val {
 	var metadata *sbom.Metadata
 	switch v := lhs.Value().(type) {
 	case *sbom.Document:
@@ -353,11 +353,13 @@ var GetMetadata = func(lhs ref.Val) ref.Val {
 var RootNodes = func(lhs ref.Val) ref.Val {
 	switch v := lhs.Value().(type) {
 	case *sbom.Document:
-		nl := &sbom.NodeList{}
-		nl.Nodes = v.GetNodeList().GetRootNodes()
-		return &elements.NodeList{
-			NodeList: nl,
+		l := []ref.Val{}
+		for _, n := range v.GetRootNodes() {
+			l = append(l, &elements.Node{
+				Node: n,
+			})
 		}
+		return types.NewRefValList(adapter.ProtobomTypeAdapter{}, l)
 	case *sbom.NodeList:
 		l := []ref.Val{}
 		for _, n := range v.GetRootNodes() {
@@ -372,7 +374,7 @@ var RootNodes = func(lhs ref.Val) ref.Val {
 }
 
 // GetNodes returns the list of nodes of the nodelist
-var NodeListGetNodes = func(lhs ref.Val) ref.Val {
+var GetNodes = func(lhs ref.Val) ref.Val {
 	switch v := lhs.Value().(type) {
 	case *sbom.NodeList:
 		l := []ref.Val{}
@@ -384,6 +386,22 @@ var NodeListGetNodes = func(lhs ref.Val) ref.Val {
 		return types.NewRefValList(adapter.ProtobomTypeAdapter{}, l)
 	default:
 		return types.NewErr("argument to RootNodes only applies to NodeList")
+	}
+}
+
+// GetNodes returns the list of nodes of the nodelist
+var GetEdges = func(lhs ref.Val) ref.Val {
+	switch v := lhs.Value().(type) {
+	case *sbom.NodeList:
+		l := []ref.Val{}
+		for _, e := range v.Edges {
+			l = append(l, &elements.Edge{
+				Edge: e,
+			})
+		}
+		return types.NewRefValList(adapter.ProtobomTypeAdapter{}, l)
+	default:
+		return types.NewErr("argument to GetEdges only applies to NodeList")
 	}
 }
 

--- a/pkg/functions/functions.go
+++ b/pkg/functions/functions.go
@@ -236,27 +236,6 @@ var LoadSBOM = func(_, pathVal ref.Val) ref.Val {
 	}
 }
 
-var NodesByPurlType = func(lhs, rhs ref.Val) ref.Val {
-	purlType, ok := rhs.Value().(string)
-	if !ok {
-		return types.NewErr("argument to GetNodesByPurlType must be a string")
-	}
-
-	var nl *sbom.NodeList
-	switch v := lhs.Value().(type) {
-	case *sbom.Document:
-		nl = v.NodeList.GetNodesByPurlType(purlType)
-	case *sbom.NodeList:
-		nl = v.GetNodesByPurlType(purlType)
-	default:
-		return types.NewErr("method unsupported on type %T", lhs.Value())
-	}
-
-	return &elements.NodeList{
-		NodeList: nl,
-	}
-}
-
 // RelateNodeListAtID relates a nodelist at the specified ID
 var RelateNodeListAtID = func(vals ...ref.Val) ref.Val {
 	if len(vals) != 4 {

--- a/pkg/functions/functions_nodelist.go
+++ b/pkg/functions/functions_nodelist.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2025 The Protobom Authors
+
+package functions
+
+import (
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/protobom/cel/pkg/adapter"
+	"github.com/protobom/cel/pkg/elements"
+	"github.com/protobom/protobom/pkg/sbom"
+)
+
+func NodeDescendants(vals ...ref.Val) ref.Val {
+	if len(vals) != 3 {
+		return types.NewErr("incorrect number of params")
+	}
+	nl, ok := vals[0].Value().(*sbom.NodeList)
+	if !ok {
+		return types.NewErr("first arg must me a nodelist")
+	}
+	id, ok := vals[1].Value().(string)
+	if !ok {
+		return types.NewErr("node id must be a string, not %T", vals[1].Value())
+	}
+	maxDepth, ok := vals[2].Value().(int64)
+	if !ok {
+		return types.NewErr("maxDepth must be an int, not %T", vals[2].Value())
+	}
+	return &elements.NodeList{NodeList: nl.NodeDescendants(id, int(maxDepth))}
+}
+
+// GetNodesByName takes a name and returns a list of nodes matching it
+func GetNodesByName(lhs, rhs ref.Val) ref.Val {
+	name, ok := rhs.Value().(string)
+	if !ok {
+		return types.NewErr("name must be a string")
+	}
+	switch v := lhs.Value().(type) {
+	case *sbom.NodeList:
+		l := []ref.Val{}
+		for _, n := range v.GetNodesByName(name) {
+			l = append(l, &elements.Node{
+				Node: n,
+			})
+		}
+		return types.NewRefValList(adapter.ProtobomTypeAdapter{}, l)
+	default:
+		return types.NewErr("no mathcing overload for GetNodesByName on %T", v)
+	}
+}
+
+var NodesByPurlType = func(lhs, rhs ref.Val) ref.Val {
+	purlType, ok := rhs.Value().(string)
+	if !ok {
+		return types.NewErr("argument to GetNodesByPurlType must be a string")
+	}
+
+	var nl *sbom.NodeList
+	switch v := lhs.Value().(type) {
+	case *sbom.Document:
+		nl = v.NodeList.GetNodesByPurlType(purlType)
+	case *sbom.NodeList:
+		nl = v.GetNodesByPurlType(purlType)
+	default:
+		return types.NewErr("method unsupported on type %T", lhs.Value())
+	}
+
+	return &elements.NodeList{
+		NodeList: nl,
+	}
+}

--- a/pkg/functions/functions_nodelist.go
+++ b/pkg/functions/functions_nodelist.go
@@ -6,9 +6,10 @@ package functions
 import (
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"github.com/protobom/protobom/pkg/sbom"
+
 	"github.com/protobom/cel/pkg/adapter"
 	"github.com/protobom/cel/pkg/elements"
-	"github.com/protobom/protobom/pkg/sbom"
 )
 
 func NodeDescendants(vals ...ref.Val) ref.Val {

--- a/pkg/library/api.go
+++ b/pkg/library/api.go
@@ -143,8 +143,16 @@ func (*Protobom) Functions() []cel.EnvOption {
 		cel.Function(
 			"get_nodes",
 			cel.MemberOverload(
-				"enodelist_get_nodes", []*cel.Type{cel.ObjectType("protobom.protobom.NodeList")}, types.NewListType(types.DynType),
-				cel.UnaryBinding(functions.NodeListGetNodes),
+				"enodelist_get_nodes", []*cel.Type{elements.NodeListType}, types.NewListType(types.DynType),
+				cel.UnaryBinding(functions.GetNodes),
+			),
+		),
+
+		cel.Function(
+			"get_edges",
+			cel.MemberOverload(
+				"enodelist_get_edges", []*cel.Type{elements.NodeListType}, types.NewListType(elements.EdgeType),
+				cel.UnaryBinding(functions.GetEdges),
 			),
 		),
 
@@ -217,13 +225,13 @@ func (*Protobom) Functions() []cel.EnvOption {
 				"sbom_get_authors",
 				[]*cel.Type{elements.DocumentType},
 				types.ListType, // result
-				cel.UnaryBinding(functions.DocumentAuthors),
+				cel.UnaryBinding(functions.GetAuthors),
 			),
 			cel.MemberOverload(
 				"metadata_get_authors",
 				[]*cel.Type{elements.MetadataType},
 				types.ListType, // result
-				cel.UnaryBinding(functions.DocumentAuthors),
+				cel.UnaryBinding(functions.GetAuthors),
 			),
 		),
 	}

--- a/pkg/library/api.go
+++ b/pkg/library/api.go
@@ -234,5 +234,24 @@ func (*Protobom) Functions() []cel.EnvOption {
 				cel.UnaryBinding(functions.GetAuthors),
 			),
 		),
+		// NodeList API functions
+		cel.Function(
+			"get_nodes_by_name",
+			cel.MemberOverload(
+				"nodelist_nodes_by_name",
+				[]*cel.Type{elements.NodeListType, types.StringType}, // args
+				types.ListType, // result
+				cel.BinaryBinding(functions.GetNodesByName), // handler
+			),
+		),
+		cel.Function(
+			"get_node_descendants",
+			cel.MemberOverload(
+				"nodelist_node_descendants",
+				[]*cel.Type{elements.NodeListType, types.StringType, types.IntType}, // args
+				elements.NodeListType,                                               // result
+				cel.FunctionBinding(functions.NodeDescendants),                      // handler
+			),
+		),
 	}
 }

--- a/pkg/library/api.go
+++ b/pkg/library/api.go
@@ -13,8 +13,8 @@ import (
 
 // Functions returns the compile-time options that define the functions that
 // the protobom library exposes to the cel environment.
-func (*Protobom) Functions() []cel.EnvOption {
-	return []cel.EnvOption{
+func (p *Protobom) Functions() []cel.EnvOption {
+	envopt := []cel.EnvOption{
 		cel.Function(
 			"get_files",
 			cel.MemberOverload(
@@ -196,15 +196,6 @@ func (*Protobom) Functions() []cel.EnvOption {
 		),
 
 		cel.Function(
-			"load_sbom",
-			cel.MemberOverload(
-				"protobom_loadsbom_binding",
-				[]*cel.Type{elements.ProtobomType, cel.StringType}, elements.DocumentType,
-				cel.BinaryBinding(functions.LoadSBOM),
-			),
-		),
-
-		cel.Function(
 			"relate_node_list_at_id",
 			cel.MemberOverload(
 				"sbom_relatenodesatid_binding",
@@ -254,4 +245,22 @@ func (*Protobom) Functions() []cel.EnvOption {
 			),
 		),
 	}
+
+	// Here we add all the functions that trigger I/O calls on the host system
+	// only if the option is enables. Most apps will not need them so we don't
+	// load them by default.
+	if p.Options.EnableIO {
+		envopt = append(
+			envopt,
+			cel.Function(
+				"load_sbom",
+				cel.MemberOverload(
+					"protobom_loadsbom_binding",
+					[]*cel.Type{elements.ProtobomType, cel.StringType}, elements.DocumentType,
+					cel.BinaryBinding(functions.LoadSBOM),
+				),
+			),
+		)
+	}
+	return envopt
 }

--- a/pkg/library/options.go
+++ b/pkg/library/options.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright 2025 The Protobom Authors
+
+package library
+
+// Options groups the knobs that can be flicked to control how the
+// library behaves when embedding it into a CEL environment
+type Options struct {
+	// EnableIO enables the functions that call to the network or the
+	// local filesystem. If false, these functions will not be available
+	// in the CEL runtime.
+	EnableIO bool
+
+	// ProtobomVarName is the name of the global variable of the protobom
+	// object that hosts all the protobom.* functions
+	ProtobomVarName string
+
+	// DocsVarName is the name of the variable that holds the loaded SBOMs.
+	DocsVarName string
+}
+
+var DefaultOptions = Options{
+	EnableIO:        false,
+	ProtobomVarName: "protobom",
+	DocsVarName:     "sboms",
+}
+
+type OptFunc func(*Options)
+
+func WithEnableIO(w bool) OptFunc {
+	return func(o *Options) {
+		o.EnableIO = w
+	}
+}
+
+func WithProtobomVarName(name string) OptFunc {
+	return func(o *Options) {
+		o.ProtobomVarName = name
+	}
+}
+
+func WithDocsVarName(name string) OptFunc {
+	return func(o *Options) {
+		o.DocsVarName = name
+	}
+}

--- a/pkg/library/protobom.go
+++ b/pkg/library/protobom.go
@@ -36,13 +36,25 @@ func (*Protobom) Types() []cel.EnvOption {
 			descriptor,
 		),
 		cel.Types(elements.DocumentType),
+		cel.Types(elements.EdgeType),
+		cel.Types(elements.ExternalReferenceType),
 		cel.Types(elements.MetadataType),
+		cel.Types(elements.NodeType),
+		cel.Types(elements.NodeListType),
 		cel.Types(elements.PersonType),
+		cel.Types(elements.PropertyType),
+		cel.Types(elements.SourceDataType),
+		cel.Types(elements.ToolType),
 		cel.Types(&sbom.Document{}),
-		cel.Types(&sbom.NodeList{}),
-		cel.Types(&sbom.Node{}),
-		cel.Types(&sbom.Person{}),
+		cel.Types(&sbom.Edge{}),
+		cel.Types(&sbom.ExternalReference{}),
 		cel.Types(&sbom.Metadata{}),
+		cel.Types(&sbom.Node{}),
+		cel.Types(&sbom.NodeList{}),
+		cel.Types(&sbom.Person{}),
+		cel.Types(&sbom.Property{}),
+		cel.Types(&sbom.SourceData{}),
+		cel.Types(&sbom.Tool{}),
 	}
 }
 
@@ -51,7 +63,6 @@ func (*Protobom) Types() []cel.EnvOption {
 func (*Protobom) Variables() []cel.EnvOption {
 	return []cel.EnvOption{
 		cel.Variable("sboms", cel.MapType(cel.IntType, elements.DocumentType)),
-		cel.Variable("docs", cel.MapType(cel.IntType, cel.DynType)),
 		cel.Variable("protobom", elements.ProtobomType),
 	}
 }

--- a/pkg/library/protobom.go
+++ b/pkg/library/protobom.go
@@ -19,10 +19,18 @@ const (
 	Name = "cel.protobom.api"
 )
 
-type Protobom struct{}
+type Protobom struct {
+	Options Options
+}
 
-func NewProtobom() *Protobom {
-	return &Protobom{}
+func NewProtobom(funcs ...OptFunc) *Protobom {
+	opts := DefaultOptions
+	for _, fn := range funcs {
+		fn(&opts)
+	}
+	return &Protobom{
+		Options: opts,
+	}
 }
 
 // Types returns the types that the library defines in the CEL environment
@@ -60,10 +68,10 @@ func (*Protobom) Types() []cel.EnvOption {
 
 // Variables defines the global variables that are created in the CEL
 // environment when the library is included
-func (*Protobom) Variables() []cel.EnvOption {
+func (p *Protobom) Variables() []cel.EnvOption {
 	return []cel.EnvOption{
-		cel.Variable("sboms", cel.MapType(cel.IntType, elements.DocumentType)),
-		cel.Variable("protobom", elements.ProtobomType),
+		cel.Variable(p.Options.DocsVarName, cel.MapType(cel.IntType, elements.DocumentType)),
+		cel.Variable(p.Options.ProtobomVarName, elements.ProtobomType),
 	}
 }
 


### PR DESCRIPTION
This is the last big PR normalizing and completing the protobom CEL APIs clearing the way for a v0.1 release.

While there is no end to convenience functions that can be added to work with the SBOM data, this PR completes the wrappers in the `elements` package, meaning that all the protobom elements can now be exposed in the CEL evaluation runtime. Specifically, this adds wrappers for:

- sbom.Edge
- sbom.ExternalReference
- sbom.Property
- sbom.SourceData
- sbom.Tool

This PR also completes the apis for the protobom elements so that all implement the Indexer trait now.


Finally, this PR adds an options set to the protobom library. The main goal is to be able to control when dangerous functions are loaded into the runtime (such as `protobom.load_sbom()`).  It adds two more options to control the name of the global variables exposed by the protobom library.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>
